### PR TITLE
Update export menu with resolving conflicts

### DIFF
--- a/Strings.ko-KR.resx
+++ b/Strings.ko-KR.resx
@@ -2742,10 +2742,10 @@
     <value>진행 방법:</value>
   </data>
   <data name="DeckExport_Label_Step1" xml:space="preserve">
-    <value>밑에 있는 덱 복사버튼을 누른다.</value>
+    <value>밑에 있는 덱 복사버튼을 누른다</value>
   </data>
   <data name="DeckExport_Label_Step2" xml:space="preserve">
-    <value>하스스톤에서 새 덱을 만든다.</value>
+    <value>하스스톤에서 새 덱을 만든다</value>
   </data>
   <data name="DeckExport_Checkbox_IncludeVersion" xml:space="preserve">
     <value>덱 버전 포함</value>

--- a/Strings.ko-KR.resx
+++ b/Strings.ko-KR.resx
@@ -1,17 +1,17 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
-  <!-- 
-    Microsoft ResX Schema 
-    
+  <!--
+    Microsoft ResX Schema
+
     Version 2.0
-    
-    The primary goals of this format is to allow a simple XML format 
-    that is mostly human readable. The generation and parsing of the 
-    various data types are done through the TypeConverter classes 
+
+    The primary goals of this format is to allow a simple XML format
+    that is mostly human readable. The generation and parsing of the
+    various data types are done through the TypeConverter classes
     associated with the data types.
-    
+
     Example:
-    
+
     ... ado.net/XML headers & schema ...
     <resheader name="resmimetype">text/microsoft-resx</resheader>
     <resheader name="version">2.0</resheader>
@@ -26,36 +26,36 @@
         <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
         <comment>This is a comment</comment>
     </data>
-                
-    There are any number of "resheader" rows that contain simple 
+
+    There are any number of "resheader" rows that contain simple
     name/value pairs.
-    
-    Each data row contains a name, and value. The row also contains a 
-    type or mimetype. Type corresponds to a .NET class that support 
-    text/value conversion through the TypeConverter architecture. 
-    Classes that don't support this are serialized and stored with the 
+
+    Each data row contains a name, and value. The row also contains a
+    type or mimetype. Type corresponds to a .NET class that support
+    text/value conversion through the TypeConverter architecture.
+    Classes that don't support this are serialized and stored with the
     mimetype set.
-    
-    The mimetype is used for serialized objects, and tells the 
-    ResXResourceReader how to depersist the object. This is currently not 
+
+    The mimetype is used for serialized objects, and tells the
+    ResXResourceReader how to depersist the object. This is currently not
     extensible. For a given mimetype the value must be set accordingly:
-    
-    Note - application/x-microsoft.net.object.binary.base64 is the format 
-    that the ResXResourceWriter will generate, however the reader can 
+
+    Note - application/x-microsoft.net.object.binary.base64 is the format
+    that the ResXResourceWriter will generate, however the reader can
     read any of the formats listed below.
-    
+
     mimetype: application/x-microsoft.net.object.binary.base64
-    value   : The object must be serialized with 
+    value   : The object must be serialized with
             : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
             : and then encoded with base64 encoding.
-    
+
     mimetype: application/x-microsoft.net.object.soap.base64
-    value   : The object must be serialized with 
+    value   : The object must be serialized with
             : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
             : and then encoded with base64 encoding.
 
     mimetype: application/x-microsoft.net.object.bytearray.base64
-    value   : The object must be serialized into a byte array 
+    value   : The object must be serialized into a byte array
             : using a System.ComponentModel.TypeConverter
             : and then encoded with base64 encoding.
     -->
@@ -337,25 +337,37 @@
     <value>덱을 선택하세요</value>
   </data>
   <data name="DeckSetIcons_Tooltip_Brm" xml:space="preserve">
-    <value>덱에 검은 바위 산 확장팩의 카드가 포함되어 있습니다.</value>
+    <value>덱에 검은 바위 산 확장팩 카드가 포함되어 있습니다.</value>
   </data>
   <data name="DeckSetIcons_Tooltip_Gvg" xml:space="preserve">
-    <value>덱에 고블린 대 노움 확장팩의 카드가 포함되어 있습니다.</value>
+    <value>덱에 고블린 대 노움 확장팩 카드가 포함되어 있습니다.</value>
   </data>
   <data name="DeckSetIcons_Tooltip_Kara" xml:space="preserve">
-    <value>덱에 한여름 밤의 카라잔 확장팩의 카드가 포함되어 있습니다.</value>
+    <value>덱에 한여름 밤의 카라잔 확장팩 카드가 포함되어 있습니다.</value>
   </data>
   <data name="DeckSetIcons_Tooltip_Loe" xml:space="preserve">
-    <value>덱에 탐험가 연맹 확장팩의 카드가 포함되어 있습니다.</value>
+    <value>덱에 탐험가 연맹 확장팩 카드가 포함되어 있습니다.</value>
   </data>
   <data name="DeckSetIcons_Tooltip_Naxx" xml:space="preserve">
-    <value>덱에 낙스라마스의 저주 확장팩의 카드가 포함되어 있습니다.</value>
+    <value>덱에 낙스라마스의 저주 확장팩 카드가 포함되어 있습니다.</value>
   </data>
   <data name="DeckSetIcons_Tooltip_Wotog" xml:space="preserve">
-    <value>덱에 고대신의 속삭임 확장팩의 카드가 포함되어 있습니다.</value>
+    <value>덱에 고대신의 속삭임 확장팩 카드가 포함되어 있습니다.</value>
   </data>
   <data name="DeckSetIcons_Tooltip_Tgt" xml:space="preserve">
-    <value>덱에 대 마상시합 확장팩의 카드가 포함되어 있습니다.</value>
+    <value>덱에 대 마상시합 확장팩 카드가 포함되어 있습니다.</value>
+  </data>
+  <data name="DeckSetIcons_Tooltip_Msg" xml:space="preserve">
+    <value>덱에 비열한 거리의 가젯잔 확장팩 카드가 포함되어 있습니다.</value>
+  </data>
+  <data name="DeckSetIcons_Tooltip_Ungoro" xml:space="preserve">
+    <value>덱에 운고로를 향한 여정 확장팩 카드가 포함되어 있습니다.</value>
+  </data>
+  <data name="DeckSetIcons_Tooltip_Icecrown" xml:space="preserve">
+    <value>덱에 얼어붙은 왕좌의 기사들 확장팩 카드가 포함되어 있습니다.</value>
+  </data>
+  <data name="DeckSetIcons_Tooltip_Loot" xml:space="preserve">
+    <value>덱에 코볼트와 지하미궁 확장팩 카드가 포함되어 있습니다.</value>
   </data>
   <data name="DeckTypeDialog_Button_Cancel" xml:space="preserve">
     <value>취소</value>
@@ -402,20 +414,32 @@
   <data name="DiscardGameDialog_Title" xml:space="preserve">
     <value>게임을 제거합니까?</value>
   </data>
+  <data name="Enum_ArenaRewardPacks_None" xml:space="preserve">
+    <value>없음</value>
+  </data>
   <data name="Enum_ArenaRewardPacks_WhispersOfTheOldGods" xml:space="preserve">
     <value>고대 신의 속삭임</value>
   </data>
   <data name="Enum_ArenaRewardPacks_TheGrandTournament" xml:space="preserve">
     <value>대 마상시합</value>
   </data>
-  <data name="Enum_ArenaRewardPacks_None" xml:space="preserve">
-    <value>없음</value>
-  </data>
   <data name="Enum_ArenaRewardPacks_GoblinsVsGnomes" xml:space="preserve">
     <value>고블린 대 노움</value>
   </data>
   <data name="Enum_ArenaRewardPacks_Classic" xml:space="preserve">
     <value>오리지널</value>
+  </data>
+  <data name="Enum_ArenaRewardPacks_MeanStreetsOfGadgetzan" xml:space="preserve">
+    <value>비열한 거리의 가젯잔</value>
+  </data>
+  <data name="Enum_ArenaRewardPacks_JourneyToUngoro" xml:space="preserve">
+    <value>운고로를 향한 여정</value>
+  </data>
+  <data name="Enum_ArenaRewardPacks_KnightsOfTheFrozenThrone" xml:space="preserve">
+    <value>얼어붙은 왕좌의 기사들</value>
+  </data>
+  <data name="Enum_ArenaRewardPacks_KoboldsAndCatacombs" xml:space="preserve">
+    <value>코볼트와 지하미궁</value>
   </data>
   <data name="Enum_ArenaImportingBehaviour_Manual" xml:space="preserve">
     <value>수동</value>
@@ -914,6 +938,18 @@
   </data>
   <data name="MainWindow_DeckBuilder_Filter_Set_Wotog" xml:space="preserve">
     <value>고대 신의 속삭임</value>
+  </data>
+  <data name="MainWindow_DeckBuilder_Filter_Set_Msg" xml:space="preserve">
+    <value>비열한 거리의 가젯잔</value>
+  </data>
+  <data name="MainWindow_DeckBuilder_Filter_Set_Ungoro" xml:space="preserve">
+    <value>운고로를 향한 여정</value>
+  </data>
+  <data name="MainWindow_DeckBuilder_Filter_Set_Icecrown" xml:space="preserve">
+    <value>얼어붙은 왕좌의 기사들</value>
+  </data>
+  <data name="MainWindow_DeckBuilder_Filter_Set_Loot" xml:space="preserve">
+    <value>코볼트와 지하미궁</value>
   </data>
   <data name="MainWindow_DeckBuilder_Filter_Type" xml:space="preserve">
     <value>종류</value>
@@ -1755,6 +1791,9 @@
   <data name="Stats_Arena_Rewards_Label_Packs_Average" xml:space="preserve">
     <value>평균:</value>
   </data>
+  <data name="Stats_Arena_Rewards_Label_Packs_Total" xml:space="preserve">
+    <value>총합:</value>
+  </data>
   <data name="Stats_Arena_Rewards_Label_Packs_Classic" xml:space="preserve">
     <value>오리지널:</value>
   </data>
@@ -1764,11 +1803,20 @@
   <data name="Stats_Arena_Rewards_Label_Packs_Tgt" xml:space="preserve">
     <value>대 마상시합:</value>
   </data>
-  <data name="Stats_Arena_Rewards_Label_Packs_Total" xml:space="preserve">
-    <value>총합:</value>
-  </data>
   <data name="Stats_Arena_Rewards_Label_Packs_Wotog" xml:space="preserve">
     <value>고대 신의 속삭임:</value>
+  </data>
+  <data name="Stats_Arena_Rewards_Label_Packs_Msg" xml:space="preserve">
+    <value>비열한 거리의 가젯잔:</value>
+  </data>
+  <data name="Stats_Arena_Rewards_Label_Packs_Ungoro" xml:space="preserve">
+    <value>운고로를 향한 여정:</value>
+  </data>
+  <data name="Stats_Arena_Rewards_Label_Packs_Icecrown" xml:space="preserve">
+    <value>얼어붙은 왕좌의 기사들:</value>
+  </data>
+  <data name="Stats_Arena_Rewards_Label_Packs_Loot" xml:space="preserve">
+    <value>코볼트와 지하미궁:</value>
   </data>
   <data name="Stats_Arena_Runs_Label" xml:space="preserve">
     <value>투기장 시도</value>

--- a/Strings.ko-KR.resx
+++ b/Strings.ko-KR.resx
@@ -2718,4 +2718,43 @@
   <data name="Options_Overlay_Streaming_Text2" xml:space="preserve">
     <value>주의: 오버레이의 복제본이 하스스톤 창 앞에 나타날 수 있습니다. 이 경우, 해당 창을 클릭해 주면 가려지게 됩니다.</value>
   </data>
+
+  <!-- Export part -->
+
+  <data name="DeckExport_Header_MissingCards" xml:space="preserve">
+    <value>없는 카드</value>
+  </data>
+  <data name="DeckExport_Label_Instructions" xml:space="preserve">
+    <value>진행 방법:</value>
+  </data>
+  <data name="DeckExport_Label_Step1" xml:space="preserve">
+    <value>밑에 있는 덱 복사버튼을 누른다.</value>
+  </data>
+  <data name="DeckExport_Label_Step2" xml:space="preserve">
+    <value>하스스톤에서 새 덱을 만든다.</value>
+  </data>
+  <data name="DeckExport_Checkbox_IncludeVersion" xml:space="preserve">
+    <value>덱 버전 포함</value>
+  </data>
+  <data name="DeckExport_Button_CopyAll" xml:space="preserve">
+    <value>덱 복사</value>
+  </data>
+  <data name="DeckExport_Button_CopyCode" xml:space="preserve">
+    <value>코드 복사</value>
+  </data>
+  <data name="DeckExport_Button_Copied" xml:space="preserve">
+    <value>복사됨!</value>
+  </data>
+  <data name="DeckExport_Text_CodeInfo" xml:space="preserve">
+    <value>하스스톤에서 덱을 불러올 경우 코드만 필요합니다. '#'로 시작하는 문장은 무시됩니다.</value>
+  </data>
+  <data name="DeckExport_MissingCards_Label_TotalCost" xml:space="preserve">
+    <value>필요한 가루:</value>
+  </data>
+  <data name="DeckExport_MissingCards_Label_StartHearthstone" xml:space="preserve">
+    <value>없는 카드를 보기위해 하스스톤을 실행하세요!</value>
+  </data>
+  <data name="DeckExport_MissingCards_Label_AllOwned" xml:space="preserve">
+    <value>모든 카드를 가지고 있습니다!</value>
+  </data>
 </root>


### PR DESCRIPTION
+ 11/11 I saw there was lots of missing Packs to translate, so, i covered this problem 

    If i had enough time, i'll translate more and change some orders
    (I'was having a trouble with reading missing parts)

+ 11/19 Could you help me with finding 'Deck Code' Header?

    this codes are in HearthstoneDeckTracker/DeckExport/DeckExportView.xaml 
    How do i find Deck code Header data Tag in String.resx?

```C#
     <TabControl>
        <TabItem Header="Deck code">
