### PR TITLE
fix typo from 旗 to 棋 in zh-CN

### DIFF
--- a/Strings.zh-CN.resx
+++ b/Strings.zh-CN.resx
@@ -3490,7 +3490,7 @@
     <value>{0}个回合前</value>
   </data>
   <data name="Options_Overlay_General_CheckBox_BattlegroundsTiers" xml:space="preserve">
-    <value>酒馆战旗各等级棋子提示</value>
+    <value>酒馆战棋各等级棋子提示</value>
   </data>
   <data name="Options_Overlay_Opponent_Label_Galakrond" xml:space="preserve">
     <value>迦拉克隆计数器：</value>


### PR DESCRIPTION
I know you no longer accept the translation trough pull request.
However nobody is available on Crowdin, https://github.com/HearthSim/HDT-Localization/issues/180
