### PR TITLE
Add missing opponent libram tracker option label

### DIFF
--- a/Strings.de-DE.resx
+++ b/Strings.de-DE.resx
@@ -3807,4 +3807,7 @@
   <data name="Options_Overlay_Player_Label_Libram" xml:space="preserve">
     <value>Show Libram cost reduction counter:</value>
   </data>
+  <data name="Options_Overlay_Opponent_Label_Libram" xml:space="preserve">
+    <value>Show Libram cost reduction counter:</value>
+  </data>
 </root>

--- a/Strings.es-ES.resx
+++ b/Strings.es-ES.resx
@@ -3807,4 +3807,7 @@
   <data name="Options_Overlay_Player_Label_Libram" xml:space="preserve">
     <value>Show Libram cost reduction counter:</value>
   </data>
+  <data name="Options_Overlay_Opponent_Label_Libram" xml:space="preserve">
+    <value>Show Libram cost reduction counter:</value>
+  </data>
 </root>

--- a/Strings.es-MX.resx
+++ b/Strings.es-MX.resx
@@ -3807,4 +3807,7 @@
   <data name="Options_Overlay_Player_Label_Libram" xml:space="preserve">
     <value>Show Libram cost reduction counter:</value>
   </data>
+  <data name="Options_Overlay_Opponent_Label_Libram" xml:space="preserve">
+    <value>Show Libram cost reduction counter:</value>
+  </data>
 </root>

--- a/Strings.fr-FR.resx
+++ b/Strings.fr-FR.resx
@@ -3807,4 +3807,7 @@
   <data name="Options_Overlay_Player_Label_Libram" xml:space="preserve">
     <value>Show Libram cost reduction counter:</value>
   </data>
+  <data name="Options_Overlay_Opponent_Label_Libram" xml:space="preserve">
+    <value>Show Libram cost reduction counter:</value>
+  </data>
 </root>

--- a/Strings.it-IT.resx
+++ b/Strings.it-IT.resx
@@ -3807,4 +3807,7 @@
   <data name="Options_Overlay_Player_Label_Libram" xml:space="preserve">
     <value>Show Libram cost reduction counter:</value>
   </data>
+  <data name="Options_Overlay_Opponent_Label_Libram" xml:space="preserve">
+    <value>Show Libram cost reduction counter:</value>
+  </data>
 </root>

--- a/Strings.ja-JP.resx
+++ b/Strings.ja-JP.resx
@@ -3807,4 +3807,7 @@
   <data name="Options_Overlay_Player_Label_Libram" xml:space="preserve">
     <value>Show Libram cost reduction counter:</value>
   </data>
+  <data name="Options_Overlay_Opponent_Label_Libram" xml:space="preserve">
+    <value>Show Libram cost reduction counter:</value>
+  </data>
 </root>

--- a/Strings.ko-KR.resx
+++ b/Strings.ko-KR.resx
@@ -3807,4 +3807,7 @@
   <data name="Options_Overlay_Player_Label_Libram" xml:space="preserve">
     <value>Show Libram cost reduction counter:</value>
   </data>
+  <data name="Options_Overlay_Opponent_Label_Libram" xml:space="preserve">
+    <value>Show Libram cost reduction counter:</value>
+  </data>
 </root>

--- a/Strings.nl-NL.resx
+++ b/Strings.nl-NL.resx
@@ -3402,4 +3402,10 @@
   <data name="MainWindow_DeckBuilder_Filter_Set_Boomsday" xml:space="preserve">
     <value>The Boomsday Project</value>
   </data>
+  <data name="Options_Overlay_Player_Label_Libram" xml:space="preserve">
+    <value>Show Libram cost reduction counter:</value>
+  </data>
+  <data name="Options_Overlay_Opponent_Label_Libram" xml:space="preserve">
+    <value>Show Libram cost reduction counter:</value>
+  </data>
 </root>

--- a/Strings.pl-PL.resx
+++ b/Strings.pl-PL.resx
@@ -3807,4 +3807,7 @@
   <data name="Options_Overlay_Player_Label_Libram" xml:space="preserve">
     <value>Show Libram cost reduction counter:</value>
   </data>
+  <data name="Options_Overlay_Opponent_Label_Libram" xml:space="preserve">
+    <value>Show Libram cost reduction counter:</value>
+  </data>
 </root>

--- a/Strings.pt-BR.resx
+++ b/Strings.pt-BR.resx
@@ -3807,4 +3807,7 @@
   <data name="Options_Overlay_Player_Label_Libram" xml:space="preserve">
     <value>Mostrar contador de redução de custo dos incunábulos:</value>
   </data>
+  <data name="Options_Overlay_Opponent_Label_Libram" xml:space="preserve">
+    <value>Mostrar contador de redução de custo dos incunábulos:</value>
+  </data>
 </root>

--- a/Strings.pt-PT.resx
+++ b/Strings.pt-PT.resx
@@ -3402,4 +3402,10 @@
   <data name="MainWindow_DeckBuilder_Filter_Set_Boomsday" xml:space="preserve">
     <value>The Boomsday Project</value>
   </data>
+  <data name="Options_Overlay_Player_Label_Libram" xml:space="preserve">
+    <value>Show Libram cost reduction counter:</value>
+  </data>
+  <data name="Options_Overlay_Opponent_Label_Libram" xml:space="preserve">
+    <value>Show Libram cost reduction counter:</value>
+  </data>
 </root>

--- a/Strings.resx
+++ b/Strings.resx
@@ -3807,4 +3807,7 @@
   <data name="Options_Overlay_Player_Label_Libram" xml:space="preserve">
     <value>Show Libram cost reduction counter:</value>
   </data>
+  <data name="Options_Overlay_Opponent_Label_Libram" xml:space="preserve">
+    <value>Show Libram cost reduction counter:</value>
+  </data>
 </root>

--- a/Strings.ru-RU.resx
+++ b/Strings.ru-RU.resx
@@ -3807,4 +3807,7 @@
   <data name="Options_Overlay_Player_Label_Libram" xml:space="preserve">
     <value>Show Libram cost reduction counter:</value>
   </data>
+  <data name="Options_Overlay_Opponent_Label_Libram" xml:space="preserve">
+    <value>Show Libram cost reduction counter:</value>
+  </data>
 </root>

--- a/Strings.th-TH.resx
+++ b/Strings.th-TH.resx
@@ -3807,4 +3807,7 @@
   <data name="Options_Overlay_Player_Label_Libram" xml:space="preserve">
     <value>Show Libram cost reduction counter:</value>
   </data>
+  <data name="Options_Overlay_Opponent_Label_Libram" xml:space="preserve">
+    <value>Show Libram cost reduction counter:</value>
+  </data>
 </root>

--- a/Strings.uk-UA.resx
+++ b/Strings.uk-UA.resx
@@ -3402,4 +3402,10 @@
   <data name="MainWindow_DeckBuilder_Filter_Set_Boomsday" xml:space="preserve">
     <value>The Boomsday Project</value>
   </data>
+  <data name="Options_Overlay_Player_Label_Libram" xml:space="preserve">
+    <value>Show Libram cost reduction counter:</value>
+  </data>
+  <data name="Options_Overlay_Opponent_Label_Libram" xml:space="preserve">
+    <value>Show Libram cost reduction counter:</value>
+  </data>
 </root>

--- a/Strings.zh-CN.resx
+++ b/Strings.zh-CN.resx
@@ -3807,4 +3807,7 @@
   <data name="Options_Overlay_Player_Label_Libram" xml:space="preserve">
     <value>Show Libram cost reduction counter:</value>
   </data>
+  <data name="Options_Overlay_Opponent_Label_Libram" xml:space="preserve">
+    <value>Show Libram cost reduction counter:</value>
+  </data>
 </root>

--- a/Strings.zh-TW.resx
+++ b/Strings.zh-TW.resx
@@ -3807,4 +3807,7 @@
   <data name="Options_Overlay_Player_Label_Libram" xml:space="preserve">
     <value>Show Libram cost reduction counter:</value>
   </data>
+  <data name="Options_Overlay_Opponent_Label_Libram" xml:space="preserve">
+    <value>Show Libram cost reduction counter:</value>
+  </data>
 </root>


### PR DESCRIPTION
<!--- ### IMPORTANT ### --> 
<!--- WE NO LONGER ACCEPT TRANSLATIONS VIA PULL REQUESTS TO THIS REPO. --> 

<!--- Please submit all translations via Crowdin -->
<!--- https://translate.hsdecktracker.net/ -->

I would submit this via Crowdin, however it doesn't let you add "translations" to english. Also, I'm not sure it would even let you add translations for labels that don't even exist yet.
